### PR TITLE
Free Merchants - new NPCs and a trading post

### DIFF
--- a/FM_GUARD.json
+++ b/FM_GUARD.json
@@ -1,0 +1,72 @@
+[ 
+  {
+    "type": "item_group",
+    "id": "TRADER_GUARD_worn",
+    "subtype": "collection",
+    "entries": [
+      { "item": "socks" },
+	  { "item": "jeans" },
+      { "item": "cloak" },
+      { "item": "hsurvivor_suit" },
+      { "item": "gloves_lsurvivor" },
+      { "item": "boots_hsurvivor" },
+      { "item": "survivor_goggles" },
+      { "item": "survivor_pack" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "TRADER_GUARD_wield",
+    "subtype": "collection",
+    "entries": [ 
+	{ "item": "m4a1" }
+	]
+  },
+  {
+    "type": "item_group",
+    "id": "TRADER_GUARD_misc",
+    "items": [
+	
+      [ "mre_chicken_box", 15 ],
+      [ "mre_beeftaco_box", 15 ],
+      [ "mre_beef_box", 15 ],
+      [ "con_milk", 10 ],
+      [ "sports_drink", 40 ],
+      [ "water_clean", 90 ],
+	  [ "meat_smoked", 10 ],
+	  [ "meat_smoked", 10 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ]
+    ]
+  },
+  
+  {
+    "type": "npc",
+    "id": "FREE_MERCHANT_GUARD",
+    "//": "Protects the merchant.",
+    "gender": "male",
+    "class": "Free_Merchant_Guard",
+    "attitude": 7,
+    "mission": 3,
+    "chat": "TALK_TRADER_GUARD",
+    "faction": "free_merchants"
+  },
+{
+    "type": "talk_topic",
+    "id": "TALK_TRADER_GUARD",
+        "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": "Speak with the boss, Marshal.",
+      "no": {
+        "u_male": "Speak with the boss, Sir.",
+        "no": "Speak with the boss, Ma'am."
+      }
+	  },
+	"responses": [ { "text": "Don't mind me...", "topic": "TALK_DONE" } ]
+  }
+  
+]

--- a/FM_TRADER.json
+++ b/FM_TRADER.json
@@ -1,0 +1,130 @@
+[   
+  {
+    "type": "item_group",
+    "id": "TRADER_worn",
+    "subtype": "collection",
+    "entries": [
+      { "item": "socks" },
+	  { "item": "jeans" },
+      { "item": "cloak" },
+      { "item": "hsurvivor_suit" },
+      { "item": "gloves_lsurvivor" },
+      { "item": "boots_hsurvivor" },
+      { "item": "survivor_goggles" },
+      { "item": "survivor_pack" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "TRADER_wield",
+    "subtype": "collection",
+    "entries": [ 
+	{ "item": "m9" }
+	]
+  },
+  {
+    "type": "item_group",
+    "id": "TRADER_misc",
+    "items": [
+	{ "group": "tools_general", "prob": 80, "repeat": [ 1, 3 ] },
+	{ "group": "magazines", "prob": 30, "repeat": [ 1, 3 ] },
+      [ "knife_combat", 10 ],
+      [ "bone_glue", 20 ],
+      [ "water_clean", 90 ],
+	  [ "meat", 40 ],
+	  [ "fish_cooked", 10 ],
+      [ "fish", 30 ],
+      [ "tallow", 10 ],
+      [ "fat", 10 ],
+      [ "dry_meat", 10 ],
+      [ "dry_fish", 10 ],
+      [ "dry_veggy", 10 ],
+      [ "dry_fruit", 10 ],
+      [ "salt", 10 ],
+      [ "pepper", 10 ],
+	  [ "fur", 10 ],
+	  [ "jacket_light", 20 ],
+      [ "jacket_leather", 20 ],
+      [ "trenchcoat", 20 ],
+      [ "jacket_jean", 20 ],
+	  [ "tshirt", 20 ],
+	  [ "chocolate", 30 ],
+      [ "can_beans", 20 ],
+      [ "mre_chilibeans_box", 15 ],
+      [ "mre_bbqbeef_box", 15 ],
+      [ "mre_chickennoodle_box", 15 ],
+      [ "mre_spaghetti_box", 15 ],
+      [ "mre_chicken_box", 15 ],
+      [ "mre_beeftaco_box", 15 ],
+      [ "mre_beef_box", 15 ],
+	  [ "1st_aid", 35 ],
+      [ "saline", 10 ],
+      [ "con_milk", 10 ],
+      [ "sports_drink", 40 ],
+      [ "water_clean", 90 ],
+	  [ "meat_smoked", 10 ],
+      [ "meat_smoked", 10 ],
+	  [ "meat_smoked", 10 ],
+	  [ "meat_smoked", 10 ],
+	  [ "meat_smoked", 10 ],
+	  [ "crowbar", 25 ],
+      [ "machete", 25 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ],
+	  [ "FMCNote", 90 ]
+    ]
+  },
+  
+  {
+    "type": "npc",
+    "id": "FREE_MERCHANT",
+    "//": "Trades in most common goods.",
+    "gender": "male",
+    "class": "Free_Merchant_Garage",
+    "attitude": 7,
+    "mission": 3,
+    "chat": "TALK_TRADER",
+    "faction": "free_merchants"
+  },
+{
+    "type": "talk_topic",
+    "id": "TALK_TRADER",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": "Marshal,  I am a member of the Free Merchants, care to trade?",
+      "no": {
+        "u_male": "Good to see you, Sir. I am an authorised member of the Free Merchants, care to trade?",
+        "no": "Good to see you, Ma'am. I am a member of the Free Merchants, care to trade?"
+      }
+	  },
+    "responses": [
+      { "text": "Free Merchants?", "topic": "TALK_TRADER_WHAT" },
+      { "text": "What are you doing here?", "topic": "TALK_TRADER_WHY" },
+      { "text": "See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+  
+    {
+    "type": "talk_topic",
+    "id": "TALK_TRADER_WHAT",
+    "dynamic_line": "We are a loose organisation, if you can even call us one. Survivors need food, medicine, clothes, scrap - and we can provide it. I made myself known to the local hunters and scavengers - they sell what they can gather, and buy what they need. Win-win.",
+    "responses": [
+      { "text": "Cheers for the free trade!", "topic": "TALK_TRADER" },
+      { "text": "Nah, I don't need anything.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_TRADER_WHY",
+    "dynamic_line": "Got my own little shop here, survivors around know where to find me. When they gather a nice loot, they sell it, and when they're starving or bleeding, they come here to get what they need. Simple.",
+    "responses": [
+      { "text": "Oh, okay.", "topic": "TALK_TRADER" }
+    ]
+  }
+
+  
+]

--- a/PS_SHEEP.json
+++ b/PS_SHEEP.json
@@ -1,0 +1,199 @@
+[ 
+ {
+    "type": "npc_class",
+    "id": "PS_SHEEP",
+    "name": "Sheep Counter",
+    "job_description": "I am counting sheep",
+    "traits": [
+      { "trait": "OUTDOORSMAN" },
+      { "trait": "HEAVYSLEEPER" },
+      { "trait": "GOODCARDIO" },
+      { "trait": "LIGHTSTEP" }
+    ],
+    "common": false,
+    "bonus_per": { "rng": [ 0, 4 ] },
+    "bonus_str": { "rng": [ 0, 4 ] },
+    "bonus_int": { "rng": [ 0, 3 ] },
+    "worn_override": "SHEEP_worn",
+    "weapon_override": "SHEEP_wield",
+    "shopkeeper_item_group": "SHEEP_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "survival", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 4, 8 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 4, 6 ] } },
+      { "skill": "bashing", "bonus": { "rng": [ 3, 6 ] } },
+      { "skill": "cutting", "bonus": { "rng": [ 3, 6 ] } }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "SHEEP_worn",
+    "subtype": "collection",
+    "entries": [
+      { "item": "socks" },
+	  { "item": "jeans" },
+      { "item": "cloak" },
+      { "item": "hsurvivor_suit" },
+      { "item": "gloves_liner" },
+      { "item": "tac_helmet" },
+      { "item": "gloves_lsurvivor" },
+      { "item": "boots_hsurvivor" },
+      { "item": "elbow_pads" },
+      { "item": "survivor_goggles" },
+      { "item": "survivor_pack" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "SHEEP_wield",
+    "subtype": "collection",
+    "entries": [ 
+	{ "item": "crossbow" }
+	]
+  },
+  {
+    "type": "item_group",
+    "id": "SHEEP_misc",
+    "items": [
+      [ "knife_combat", 90 ],
+      [ "bone_glue", 20 ],
+      [ "water_clean", 90 ],
+	  [ "meat", 40 ],
+	  [ "fish_cooked", 10 ],
+      [ "fish", 30 ],
+      [ "tallow", 10 ],
+      [ "fat", 10 ],
+      [ "dry_meat", 10 ],
+      [ "dry_fish", 10 ],
+      [ "dry_veggy", 10 ],
+      [ "dry_fruit", 10 ],
+      [ "salt", 10 ],
+      [ "pepper", 10 ],
+	  [ "fur", 10 ]
+    ]
+  },
+  
+  {
+    "type": "npc",
+    "id": "SHEEP_COUNTER",
+    "//": "A seasoned hunter who knows how to save the world.",
+    "gender": "male",
+    "class": "PS_SHEEP",
+    "attitude": 7,
+    "mission": 3,
+    "chat": "TALK_SHEEP",
+    "faction": "wasteland_scavengers",
+    "mission_offered": "MISSION_SHEEP_GATHER"
+  },
+{
+    "type": "talk_topic",
+    "id": "TALK_SHEEP",
+    "dynamic_line": { "u_is_wearing": "badge_marshal", "yes": "I know the secret, Marshal.", "no": "I know the secret." },
+    "responses": [
+      { "text": "What is the secret?", "topic": "TALK_SHEEP_WHAT" },
+      { "text": "What are you doing here?", "topic": "TALK_SHEEP_WHY" },
+      { "text": "Anything I can do for you?", "topic": "TALK_MISSION_LIST" },
+	  { "text": "You're an idiot.", "topic": "TALK_SHEEP_IDIOT" },
+      { "text": "See you later.", "topic": "TALK_SHEEP_BYE" }
+    ]
+  },
+  
+    {
+    "type": "talk_topic",
+    "id": "TALK_SHEEP_WHAT",
+    "dynamic_line": "The world ended because at some point we got comfortable enough to stop paying attention to the delicate 'sheep equilibrium'.",
+    "responses": [
+      { "text": "Sheep equilibrium?", "topic": "TALK_SHEEP_KNOW" },
+      { "text": "Okay, I'm done.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_SHEEP_KNOW",
+    "dynamic_line": "Yes. They hold the secret. The world rests on a very delicate equilibrium and the key is to count them, at all times. I keep a detailed log in my head... we may still be able to undo everything! When the time is right, I'll publish a paper, reveal the secret to the broader scientific community and we'll work together to stop the cataclysm.",
+    "responses": [
+      { "text": "Oh, okay.", "topic": "TALK_SHEEP" },
+	  { "text": "You do realise that there is no scientific community to speak of anymore, right?", "topic": "TALK_SHEEP_SCIENCE" },
+      { "text": "Okay, I'm done. See ya.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+     {
+    "type": "talk_topic",
+    "id": "TALK_SHEEP_SCIENCE",
+    "dynamic_line": "There is a Hub of world's greatest minds out there. They told me to keep counting for now, and so I shall. I do not intend to let them down, I must keep a very detailed log, in my head, so no one can take it from me.",
+    "responses": [
+      { "text": "How many sheep have you counted so far?", "topic": "TALK_SHEEP_MANY" },
+      { "text": "Okay, I'm done.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+  {
+      "type": "talk_topic",
+    "id": "TALK_SHEEP_MANY",
+    "dynamic_line": "Sixty-eight white, eleven brown, eight black, three red, two pink and one blue. See? Very detailed.",
+    "responses": [
+      { "text": "That's... fascinating.", "topic": "TALK_SHEEP" },
+      { "text": "Okay, I'm done.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+  {
+      "type": "talk_topic",
+    "id": "TALK_SHEEP_WHY",
+    "dynamic_line": "I'm counting sheep. I'm also hunting and fishing around these parts. But I never kill sheep. I just count them. Very important. You can kill, I can't, but I must count. Must. Always.",
+    "responses": [
+      { "text": "Great.", "topic": "TALK_SHEEP" },
+      { "text": "Okay, I'm done.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+  
+      {
+      "type": "talk_topic",
+    "id": "TALK_SHEEP_IDIOT",
+    "dynamic_line": "Stupid is as stupid does. I guess you just can't grasp the secret. I don't blame you, takes a titanic intellect to do so.",
+    "responses": [
+      { "text": "Of course.", "topic": "TALK_SHEEP" },
+	  { "text": "There are... no words.", "topic": "TALK_DONE" },
+	  { "text": "Uh, huh.", "topic": "TALK_SHEEP" },
+      { "text": "Okay, I'm done.", "topic": "TALK_DONE" }
+    ]
+  },
+  
+    {
+    "type": "talk_topic",
+    "id": "TALK_SHEEP_BYE",
+    "dynamic_line": "I'll be counting.",
+    "responses": [ { "text": "...", "topic": "TALK_DONE" } ]
+  },
+  
+  {
+    "id": "MISSION_SHEEP_GATHER",
+    "type": "mission_definition",
+    "name": "I need new bolts for my crossbow.",
+    "description": "Help the odd hunter by finding 50 steel bolts for his crossbow.",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 2,
+    "value": 800,
+    "item": "bolt_steel",
+    "count": 50,
+    "origins": [ "ORIGIN_SECONDARY" ],
+	"end": { "effect": [ { "u_buy_item": "RobofacCoin", "count": 4 } ] },
+    "dialogue": {
+      "describe": "I'm running low on bolts for my crossbow.",
+      "offer": "I've been hunting for a while now, and good quality steel bolts are really hard to come by these days. Could you bring me, let's say, 50 steel bolts? You'd be a real lifesaver. I have some Hub coins for your troubles.",
+      "accepted": "Thanks, it's good to know that kindness is not gone from this world.",
+      "rejected": "That's fine, you cannot expect a stranger to care.",
+      "advice": "There must be some hunting gear in survival shops, but towns can be very dangerous these days.",
+      "inquire": "Do you have the bolts?",
+      "success": "Thanks! You're absolutely amazing!",
+      "success_lie": "OK, then hand them over.",
+      "failure": "That's fine. I know it's not an easy task."
+    }
+  }
+]

--- a/classes.json
+++ b/classes.json
@@ -1,0 +1,497 @@
+[
+  {
+    "type": "npc_class",
+    "id": "NC_NONE",
+    "name": "No class",
+    "job_description": "I'm just wandering.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_TEST_CLASS",
+    "name": "Debug Dude",
+    "job_description": "I'm helping you test the game.",
+    "common": false,
+    "bonus_str": 100,
+    "bonus_dex": { "dice": [ 10, 10 ] },
+    "bonus_int": { "one_in": 2 },
+    "bonus_per": { "sum": [ { "constant": 100 }, { "dice": [ 10, 10 ] } ] },
+    "worn_override": "NC_DEBUG_worn",
+    "carry_override": "NC_DEBUG_carried",
+    "weapon_override": "NC_DEBUG_weapon",
+    "traits": [ [ "DEBUG_NODMG", 100 ] ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SHOPKEEP",
+    "name": "Shopkeep",
+    "job_description": "I'm a local shopkeeper.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "//": "This is a unique NPC who doesn't get randomly selected background traits",
+    "common": false
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_HACKER",
+    "name": "Hacker",
+    "job_description": "I'm looking for some choice systems to hack.",
+    "traits": [
+      { "group": "BG_survival_story_TEENAGER" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" }
+    ],
+    "bonus_str": { "rng": [ -4, 0 ] },
+    "bonus_dex": { "rng": [ -2, 0 ] },
+    "bonus_int": { "rng": [ 1, 5 ] },
+    "bonus_per": { "rng": [ -2, 0 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ -1, -2 ] } ] } ] } },
+      { "skill": "electronics", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "computer", "bonus": { "rng": [ 3, 6 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_DOCTOR",
+    "name": "Doctor",
+    "job_description": "I'm looking for wounded to help.",
+    "traits": [ { "group": "BG_survival_story_MEDICAL" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ -2, 0 ] },
+    "bonus_int": { "rng": [ 0, 2 ] },
+    "bonus_per": { "one_in": 4 },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 3, 2 ] }, { "rng": [ -1, -3 ] } ] } ] } },
+      { "skill": "firstaid", "bonus": { "rng": [ 2, 6 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_TRADER",
+    "name": "Trader",
+    "job_description": "I'm collecting gear and selling it.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_int": { "one_in": 4 },
+    "bonus_per": { "one_in": 4 }
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_NINJA",
+    "name": "Ninja",
+    "job_description": "I'm a wandering master of martial arts.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ -1, 0 ] },
+    "bonus_dex": { "rng": [ 0, 2 ] },
+    "bonus_per": { "rng": [ 0, 2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ -1, -2 ] } ] } ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 1, 4 ] } },
+      { "skill": "unarmed", "bonus": { "rng": [ 4, 6 ] } },
+      { "skill": "throw", "bonus": { "rng": [ 0, 2 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_COWBOY",
+    "name": "Cowboy",
+    "job_description": "Just looking for some wrongs to right.",
+    "traits": [ { "group": "BG_survival_story_RURAL" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ 0, 1 ] },
+    "bonus_int": { "rng": [ -2, 0 ] },
+    "bonus_per": { "rng": [ 0, 2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -4 ] } ] } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 2 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_MARLOSS_VOICE",
+    "name": "Marloss Voice",
+    "job_description": "I spread the Hymns so that peace and unity return to our world.",
+    "traits": [
+      { "group": "BG_survival_story_RURAL" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      [ "MARLOSS", 100 ],
+      [ "MARLOSS_BLUE", 40 ],
+      [ "MYCUS_FRIEND", 100 ],
+      [ "FLIMSY2", 100 ]
+    ],
+    "common": false,
+    "worn_override": "NC_VOICE_worn",
+    "carry_override": "NC_VOICE_carry",
+    "weapon_override": "NC_VOICE_weapon",
+    "bonus_str": { "rng": [ 0, 1 ] },
+    "bonus_int": { "rng": [ -2, 0 ] },
+    "bonus_per": { "rng": [ 0, 2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -4 ] } ] } ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "unarmed", "bonus": { "rng": [ 1, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SCIENTIST",
+    "name": "Scientist",
+    "job_description": "I'm looking for clues concerning these monsters' origins...",
+    "traits": [ { "group": "BG_survival_story_LAB" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ -1, -3 ] },
+    "bonus_dex": { "rng": [ -1, 0 ] },
+    "bonus_int": { "rng": [ 2, 5 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -4 } ] } ] } },
+      { "skill": "computer", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "electronics", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "firstaid", "bonus": { "rng": [ 1, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_BOUNTY_HUNTER",
+    "name": "Bounty Hunter",
+    "job_description": "I'm a killer for hire.",
+    "traits": [ { "group": "BG_survival_story_POLICE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 2, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_THUG",
+    "name": "Thug",
+    "job_description": "I'm just here for the paycheck.",
+    "traits": [
+      { "group": "BG_survival_story_CRIMINAL" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" }
+    ],
+    "bonus_str": { "rng": [ 2, 4 ] },
+    "bonus_dex": { "rng": [ 0, 2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -4 } ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "unarmed", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "bashing", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "stabbing", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "cutting", "bonus": { "rng": [ 1, 5 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SCAVENGER",
+    "name": "Scavenger",
+    "job_description": "I'm just trying to survive.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ARSONIST",
+    "name": "Arsonist",
+    "job_description": "I'm just watching the world burn.",
+    "traits": [
+      { "group": "BG_survival_story_CRIMINAL" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" }
+    ],
+    "bonus_dex": { "rng": [ -2, 0 ] },
+    "bonus_int": { "rng": [ -2, 0 ] },
+    "bonus_per": { "rng": [ 0, 2 ] },
+    "shopkeeper_item_group": "NC_ARSONIST_misc",
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "rng": [ 0, -4 ] } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "throw", "bonus": { "rng": [ 0, 2 ] } },
+      { "skill": "barter", "bonus": { "rng": [ 2, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_HUNTER",
+    "name": "Hunter",
+    "job_description": "I'm tracking game.",
+    "traits": [ { "group": "BG_survival_story_RURAL" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ -2, 0 ] },
+    "bonus_dex": { "rng": [ -3, -1 ] },
+    "bonus_per": { "rng": [ 2, 4 ] },
+    "shopkeeper_item_group": "NC_HUNTER_misc",
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "rng": [ 0, -4 ] } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "barter", "bonus": { "rng": [ 2, 5 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SOLDIER",
+    "name": "Soldier",
+    "job_description": "I'm just here for the paycheck.",
+    "traits": [ { "group": "BG_survival_story_SOLDIER" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ 0, 2 ] },
+    "bonus_dex": { "one_in": 2 },
+    "bonus_int": { "rng": [ 0, -2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 1, 2 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 1, 2 ] } },
+      { "skill": "unarmed", "bonus": { "rng": [ 1, 2 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 3, 5 ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_BARTENDER",
+    "name": "Bartender",
+    "job_description": "I'm looking for new drink recipes.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
+    "bonus_per": { "one_in": 4 },
+    "shopkeeper_item_group": "NC_BARTENDER_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "speech", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "barter", "bonus": { "rng": [ 2, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_JUNK_SHOPKEEP",
+    "name": "Shopkeep",
+    "job_description": "I'm a local shopkeeper.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "//": "This is a unique NPC who doesn't get randomly selected background traits",
+    "common": false,
+    "bonus_per": { "one_in": 4 },
+    "shopkeeper_item_group": "NC_JUNK_SHOPKEEP_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "speech", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "barter", "bonus": { "rng": [ 2, 4 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_APIS",
+    "name": "Apis",
+    "job_description": "I'm bugged - I shouldn't talk to you.",
+    "common": false,
+    "bonus_dex": { "rng": [ 5, 10 ] },
+    "bonus_int": { "rng": [ -4, -8 ] },
+    "bonus_per": { "rng": [ 4, 8 ] },
+    "skills": [
+      { "skill": "dodge", "level": { "dice": [ 2, 2 ] } },
+      { "skill": "melee", "level": { "dice": [ 2, 2 ] } },
+      { "skill": "unarmed", "level": { "dice": [ 2, 2 ] } }
+    ],
+    "worn_override": "EMPTY_GROUP",
+    "carry_override": "EMPTY_GROUP",
+    "weapon_override": "EMPTY_GROUP",
+    "//": "NPCs can't run yet and we want this one to be fast, so road runner.",
+    "//": "This is a unique NPC who doesn't get randomly selected background traits",
+    "traits": [
+      [ "THRESH_INSECT", 100 ],
+      [ "BEE", 100 ],
+      [ "MANDIBLES", 100 ],
+      [ "TAIL_STING", 100 ],
+      [ "INSECT_ARMS_OK", 100 ],
+      [ "CHITIN3", 100 ],
+      [ "POISONOUS2", 100 ],
+      [ "PAINRESIST", 100 ],
+      [ "ADRENALINE", 100 ],
+      [ "FLEET2", 100 ],
+      [ "ANTENNAE", 100 ]
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_HALLU",
+    "name": "Real Person",
+    "job_description": "I'm just wandering, like a totally real and normal NP... Person!",
+    "traits": [ { "group": "BG_survival_story_UNIVERSAL" }, { "group": "NPC_starting_traits" }, [ "HALLUCINATION", 100 ] ],
+    "common": false,
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_SURVIVOR_CHEF",
+    "name": "Chef",
+    "job_description": "I'm a chef.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
+    "bonus_per": { "one_in": 4 },
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "throw", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "cooking", "bonus": { "rng": [ 3, 6 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_TRUE_FOODPERSON",
+    "name": "Foodperson",
+    "job_description": "I AM FOODPERSON. AND I BRING SUSTENANCE!",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, [ "PROF_FOODP", 100 ] ],
+    "common": false,
+    "worn_override": "NC_TRUE_FOODPERSON_worn",
+    "weapon_override": "NC_TRUE_FOODPERSON_melee",
+    "bonus_str": { "rng": [ 0, 2 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } },
+      { "skill": "bashing", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "speech", "bonus": { "rng": [ 1, 3 ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 3, 6 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_CYBORG",
+    "name": "Cyborg",
+    "job_description": "Zzzzzt... I...I'm a Cy...BEEEEEP...borg.",
+    "traits": [ { "group": "BG_survival_story_CYBORG" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } }
+    ],
+    "common": false,
+    "worn_override": "NC_CYBORG_worn",
+    "carry_override": "NC_CYBORG_carried",
+    "weapon_override": "EMPTY_GROUP",
+    "bionics": [
+      { "id": "bio_ankles", "chance": 100 },
+      { "id": "bio_dis_shock", "chance": 100 },
+      { "id": "bio_dis_acid", "chance": 100 },
+      { "id": "bio_drain", "chance": 100 },
+      { "id": "bio_noise", "chance": 100 },
+      { "id": "bio_power_weakness", "chance": 100 },
+      { "id": "bio_itchy", "chance": 100 },
+      { "id": "bio_nostril", "chance": 100 },
+      { "id": "bio_thumbs", "chance": 100 },
+      { "id": "bio_spasm", "chance": 100 },
+      { "id": "bio_shakes", "chance": 100 },
+      { "id": "bio_leaky", "chance": 100 },
+      { "id": "bio_sleepy", "chance": 100 },
+      { "id": "bio_deformity", "chance": 100 },
+      { "id": "bio_voice", "chance": 100 },
+      { "id": "bio_pokedeye", "chance": 100 },
+      { "id": "bio_ankles", "chance": 100 },
+      { "id": "bio_trip", "chance": 100 },
+      { "id": "bio_stiff", "chance": 100 },
+      { "id": "bio_armor_head", "chance": 100 },
+      { "id": "bio_armor_torso", "chance": 100 },
+      { "id": "bio_armor_arms", "chance": 100 },
+      { "id": "bio_armor_legs", "chance": 100 },
+      { "id": "bio_armor_eyes", "chance": 100 },
+      { "id": "bio_razors", "chance": 100 },
+      { "id": "bio_power_storage", "chance": 100 },
+      { "id": "bio_torsionratchet", "chance": 100 }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_CITY_COP",
+    "name": "former cop",
+    "job_description": "I used to be a police officer, but I'm just a survivor now.",
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
+    "bonus_per": { "one_in": 4 },
+    "shopkeeper_item_group": "NC_CITY_COP_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "barter", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "gun", "bonus": { "rng": [ 4, 8 ] } },
+      { "skill": "melee", "bonus": { "rng": [ 3, 6 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 3, 6 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 3, 6 ] } }
+    ]
+  },
+    
+	{
+    "type": "npc_class",
+    "id": "FM_GUARD",
+    "name": "FM_GUARD",
+    "job_description": "I am defending the merchant.",
+    "traits": [
+      { "trait": "OUTDOORSMAN" },
+      { "trait": "HEAVYSLEEPER" },
+      { "trait": "GOODCARDIO" },
+      { "trait": "LIGHTSTEP" }
+    ],
+    "common": false,
+    "bonus_per": { "rng": [ 0, 4 ] },
+    "bonus_str": { "rng": [ 0, 4 ] },
+    "bonus_int": { "rng": [ 0, 3 ] },
+    "worn_override": "TRADER_GUARD_worn",
+    "weapon_override": "TRADER_GUARD_wield",
+    "shopkeeper_item_group": "TRADER_GUARD_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "dodge", "bonus": { "rng": [ 4, 8 ] } }
+    ]
+  },
+  
+  {
+    "type": "npc_class",
+    "id": "FM_GARAGE",
+    "name": "FM_GARAGE",
+    "job_description": "I am trading stuff",
+    "traits": [
+      { "trait": "OUTDOORSMAN" },
+      { "trait": "HEAVYSLEEPER" },
+      { "trait": "GOODCARDIO" },
+      { "trait": "LIGHTSTEP" }
+    ],
+    "common": false,
+    "bonus_per": { "rng": [ 0, 4 ] },
+    "bonus_str": { "rng": [ 0, 4 ] },
+    "bonus_int": { "rng": [ 0, 3 ] },
+    "worn_override": "TRADER_worn",
+    "weapon_override": "TRADER_wield",
+    "shopkeeper_item_group": "TRADER_misc",
+    "skills": [
+      {
+        "skill": "ALL",
+        "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
+      },
+      { "skill": "barter", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "dodge", "bonus": { "rng": [ 4, 8 ] } }
+    ]
+  }
+]

--- a/garage_trader.json
+++ b/garage_trader.json
@@ -1,0 +1,127 @@
+[
+{
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "s_garage_trader" ],
+    "weight": 1000,
+    "object": {
+      "fill_ter": "t_thconc_floor",
+      "rows": [
+        "     EEEEEE    EEEEEE   ",
+        "     EEEEEE    EEEEEE   ",
+        "     EEEEEE    EEEEEE   ",
+        "     EEEEEE    EEEEEE   ",
+        "    eEEEEEE   eEEEEEEEEE",
+        " ----======----======--E",
+        " |S.eM#MM#M...eM#MM#M.|E",
+        " |S..M#MM#M....M#MM#M.|E",
+        " |c..M#MM#M....M#MM#M.|E",
+        " |c..M#MM#M....M#MM#M.|E",
+        " |c..M#MM#M....M#MM#M.|E",
+        " |c..M#MM#M....M#MM#M.|E",
+        " |c..MMMMMMMMMMMMMMMM.|E",
+        " |....................|E",
+        " |---l...........HHHHH|E",
+        " |ts|c...........HLLLL|E",
+        " |-+|p...........Hbbbb|E",
+        "4|...............$....+E",
+        " |^W|............Hhbbb|E",
+        " |xx|cccccSScccccH6LLL|E",
+        " |----::::--::::------|E",
+        "                  EU<UEE",
+        "                  EUEEEE",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ [ "t_grass", 5 ], [ "t_grass_long", 2 ], "t_dirt", "t_shrub" ],
+        "E": "t_pavement",
+        "U": "t_pavement",
+        "$": "t_door_glass_c",
+        "+": "t_door_c",
+        "-": "t_brick_wall",
+        ".": "t_thconc_floor",
+        "6": "t_console_broken",
+        ":": "t_window",
+        "=": "t_door_metal_locked",
+        "A": "t_m_frame",
+        "H": "t_wall_glass",
+        "e": "t_gates_mech_control",
+        "|": "t_brick_wall",
+        "W": "t_chainfence_h",
+        "^": "t_chaingate_c",
+        "M": "t_metal_floor",
+        "#": "t_grate",
+        "4": "t_gutter_downspout",
+        "<": "t_ladder_up"
+      },
+      "furniture": {
+        "A": "f_air_conditioner",
+        "L": "f_locker",
+        "b": "f_bench",
+        "c": "f_counter",
+        "s": "f_sink",
+        "S": "f_utility_shelf",
+        "p": "f_hydraulic_press",
+        "l": "f_heavy_lathe",
+        "t": "f_toilet",
+        "x": "f_crate_c",
+        "h": "f_chair",
+        "U": [ "f_dumpster", "f_recycle_bin" ]
+      },
+      "items": {
+        "L": { "item": "clothing_work_set", "chance": 25 },
+        "c": { "item": "mechanics", "chance": 30 },
+        "S": { "item": "mechanics", "chance": 40, "repeat": 4 },
+        "x": { "item": "mechanics", "chance": 50, "repeat": 2 }
+      },
+      "place_npcs": [
+        { "class": "FM_GUARD", "x": 9, "y": 10 },
+		{ "class": "FM_GUARD", "x": 7, "y": 10 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "s_garage__trader_roof",
+    "object": {
+      "fill_ter": "t_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        " |222222222222222222223 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....................3 ",
+        " |....&...............3 ",
+        " 5....................3 ",
+        " |..........AA........3 ",
+        " |.=..................3 ",
+        " |----------------##### ",
+        "                  ##>## ",
+        "                  ####  ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ">": "t_ladder_down" },
+      "place_items": [ { "item": "roof_trash", "x": [ 4, 20 ], "y": [ 7, 18 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_nested": [
+        {
+          "chunks": [ [ "null", 20 ], [ "roof_2x2_utilities_b", 40 ], [ "roof_2x2_utilities_c", 40 ] ],
+          "x": [ 3, 15 ],
+          "y": [ 8, 12 ]
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
#### Summary

 ```SUMMARY: Content A garage trading post with a merchant and two guards.```


#### Purpose of change

I believe that the game needs more trading outposts where players can exchange items. We already have a faction to do it, why not expand it a bit?

Overall, this should add another level of plausibility to this world - a traveling merchant who brings various individuals - hunters, fishermen, scavengers, and other survivors together through trade. 

#### Describe the solution

1. Two new NPC classes - a field merchant and a guard. 
2. A new mapgen building - a copy of the existing garage, but with the merchant and two guards in it.  

#### Problem

As of this moment, the game fails to recognize the new NPC classes that I've added to classes.json. I would greatly appreciate any help to make them work . 